### PR TITLE
:construction_worker: Harden generated-data workflows

### DIFF
--- a/.github/workflows/stethoscope.yml
+++ b/.github/workflows/stethoscope.yml
@@ -5,15 +5,18 @@ on:
   repository_dispatch:
     types: [stethoscope]
   workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: false
 jobs:
   release:
     name: Daily
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v6.0.2
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.head_ref || github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Update data using Stethoscope
         uses: stethoscope-js/action@master
@@ -48,7 +51,7 @@ jobs:
           TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
           TWITTER_SCREEN_NAME: ${{ secrets.TWITTER_SCREEN_NAME }}
       - name: Commit new data
-        uses: stefanzweifel/git-auto-commit-action@v4.15.4
+        uses: stefanzweifel/git-auto-commit-action@v7.1.0
         with:
           commit_message: ":card_file_box: Update daily life data [skip ci]"
           commit_user_name: Stethoscoper

--- a/.github/workflows/update-template.yml
+++ b/.github/workflows/update-template.yml
@@ -5,24 +5,27 @@ on:
   repository_dispatch:
     types: [update_template]
   workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: false
 jobs:
   release:
     name: Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v6.0.2
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.head_ref || github.ref_name }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Setup Node.js
-        uses: actions/setup-node@v3.5.1
+        uses: actions/setup-node@v6.4.0
         with:
-          node-version: 16.18.0
+          node-version: 20
       - name: Update template
         run: npx update-template https://github.com/stethoscope-js/stethoscope
       - name: Commit new data
-        uses: stefanzweifel/git-auto-commit-action@v4.15.4
+        uses: stefanzweifel/git-auto-commit-action@v7.1.0
         with:
           commit_message: ":arrow_up: Update @stethoscope-js to latest"
           commit_user_name: Stethoscoper


### PR DESCRIPTION
## Summary
- adds concurrency guards to the scheduled/generated-data workflows so overlapping runs queue instead of racing commits
- checks out the live event branch/ref for scheduled and manual runs
- updates workflow actions and the template refresh Node runtime to current supported versions

## Test Plan
- YAML parsed with PyYAML
- `git diff --check`
- `actionlint .github/workflows/*.yml`
- verified upgraded action tags and existing inputs via GitHub API

Note: I did not manually dispatch these workflows because both can commit generated data back to the repo.