### PR TITLE
:arrow_up: Update workflow actions

### DIFF
--- a/.github/workflows/stethoscope.yml
+++ b/.github/workflows/stethoscope.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
         with:
           ref: ${{ github.head_ref || github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -51,7 +51,7 @@ jobs:
           TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
           TWITTER_SCREEN_NAME: ${{ secrets.TWITTER_SCREEN_NAME }}
       - name: Commit new data
-        uses: stefanzweifel/git-auto-commit-action@v7.1.0
+        uses: stefanzweifel/git-auto-commit-action@v7.2.0
         with:
           commit_message: ":card_file_box: Update daily life data [skip ci]"
           commit_user_name: Stethoscoper

--- a/.github/workflows/update-template.yml
+++ b/.github/workflows/update-template.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
         with:
           ref: ${{ github.head_ref || github.ref_name }}
           token: ${{ secrets.GH_PAT || github.token }}
@@ -25,7 +25,7 @@ jobs:
       - name: Update template
         run: npx update-template https://github.com/stethoscope-js/stethoscope
       - name: Commit new data
-        uses: stefanzweifel/git-auto-commit-action@v7.1.0
+        uses: stefanzweifel/git-auto-commit-action@v7.2.0
         with:
           commit_message: ":arrow_up: Update @stethoscope-js to latest"
           commit_user_name: Stethoscoper


### PR DESCRIPTION
## Summary
- update `actions/checkout` from `v6.0.2` to `v7.0.0`
- update `stefanzweifel/git-auto-commit-action` from `v7.1.0` to `v7.2.0`
- keep both scheduled, branch-mutating workflows on current Node 24 action runtimes

## Test plan
- [x] Parse both workflow files as YAML
- [x] Run `actionlint` on both workflow files
- [x] Verify both action tags and their `action.yml` metadata through the GitHub API
- [x] Run `git diff --check`
- [x] Scan added lines for hardcoded secrets and dangerous execution patterns

The workflows can commit generated data, so they were not manually dispatched from the PR branch.